### PR TITLE
fix: Path for netlify

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,14 +8,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <title>Clube Penguin🐧</title>
-    <link rel="shortcut icon" href="/src/img/livro-biquinho-didatico.png" type="image/x-icon">
+    <link rel="shortcut icon" href="./img/livro-biquinho-didatico.png" type="image/x-icon">
     <link href="index.css" rel="stylesheet">
 </head>
 
 <body>
     <!--cabeçalho🤯-->
     <header class="header-menu">
-        <img class="header-logo" src="/src/img/penguin-livrinhobeijo 2.svg" alt="logo pinguim com livrinho do biquinho">
+        <img class="header-logo" src="./img/penguin-livrinhobeijo 2.svg" alt="logo pinguim com livrinho do biquinho">
 
         <nav class="header-menu-nav">
             <a href="#sobre"class="header-menu-item">Sobre o projeto</a>
@@ -27,12 +27,12 @@
 
     <main class="conteudo-principal">
         <section>
-            <img class="conteudo-principal-imagem" src="/src/img/background-completinho.png" alt="imagem de fundo do clube penguin">
+            <img class="conteudo-principal-imagem" src="./img/background-completinho.png" alt="imagem de fundo do clube penguin">
             <div class="conteudo-principal-sobre">
                 <p id="sobre">Clube Penguin é uma comunidade de apoio e incentivo a leitura para estudantes de baixa renda. 
                     Disponibilizando alguns livros em formato .pdf com temas diversos, promovendo educação e socialização entre as pessoas.
                 </p>
-            <img class="conteudo-principal-livrinho-mundo" src="/src/img/book-world.png" alt="imagem de livro com globo terrestre no fundo">
+            <img class="conteudo-principal-livrinho-mundo" src="./img/book-world.png" alt="imagem de livro com globo terrestre no fundo">
             </div>
         </section>
     </main>
@@ -103,10 +103,10 @@
         <br/> <br/>
     <div class="conteudos-participe-comunidades-redes">
         <div class="conteudos-participe-comunidades-discord">
-           <a href="https://discord.com/" target="_blank"><img src="/src/img/logo-discord.svg" alt="logo discord"></a>
+           <a href="https://discord.com/" target="_blank"><img src="./img/logo-discord.svg" alt="logo discord"></a>
         </div>
         <div class="conteudos-participe-comunidades-telegram">
-            <a href="https://telegram.org/" target="_blank"><img src="/src/img/logo-telegram.svg" alt="logo telegram"></a>
+            <a href="https://telegram.org/" target="_blank"><img src="./img/logo-telegram.svg" alt="logo telegram"></a>
         </div>
     </div>
     </section>
@@ -115,12 +115,12 @@
 <br/> <br/> <br/>
 <footer class="footer" id="contato">
     <div class="div-footer">
-        <img class="pingu-footer" src="/src/img/meu pingu 1.svg" alt="imagem de pinguim">
+        <img class="pingu-footer" src="./img/meu pingu 1.svg" alt="imagem de pinguim">
 
         <p class="footer-frase-final">Desenvolvido com carinho por, <strong class="nome-gica">Gica</strong></p>
 
-        <a class="footer-logo" href="https://www.linkedin.com/in/giovanna-alves-gica/" target="_blank"><img src="/src/img/logo-linkedin-ok.svg" alt="logo linkedin"></a>
-        <a class="footer-logo" href="https://github.com/gicaAlves" target="_blank"><img src="/src/img/GitHub.svg" alt="logo github"></a>
+        <a class="footer-logo" href="https://www.linkedin.com/in/giovanna-alves-gica/" target="_blank"><img src="./img/logo-linkedin-ok.svg" alt="logo linkedin"></a>
+        <a class="footer-logo" href="https://github.com/gicaAlves" target="_blank"><img src="./img/GitHub.svg" alt="logo github"></a>
     
     </div>
 </footer>


### PR DESCRIPTION
Como a estrutura de diretórios do repositório é:

- README.md
- src/

Foi necessário no Netlify definir o `src/` como o root, assim, no site, todos os recursos acessados a partir do diretório `/` na url, acessa os arquivos dentro do `src`.

Contudo, no código, os caminhos das imagens estavam com o `src/<caminho>`, sendo que o root já era o `src`, o que, na prática, fazia com que o recurso fosse procurado no `src/src/<caminho>`.

Substituindo `src/<caminho>` por apenas `<caminho>`, o problema é resolvido.

:shipit: :octocat: